### PR TITLE
feat: Validate Password Hint

### DIFF
--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -467,7 +467,7 @@ const Login: React.FC = () => {
                 >
                   {strings('login.password')}
                 </Label>
-                {showHint && (
+                {hintText && (
                   <Button
                     variant={ButtonVariants.Link}
                     onPress={toggleHint}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4055,7 +4055,8 @@
     "button": "Create hint",
     "placeholder": "e.g. mom’s home",
     "saved": "Save",
-    "saved_toast": "Password hint updated"
+    "saved_toast": "Password hint updated",
+    "error_matches_password": "You cannot use your password as a hint"
   },
   "protect_your_wallet": {
     "title": "Protect your wallet",


### PR DESCRIPTION
Adds validation to the Password Hint screen to prevent users from setting their password as the hint.

-   Introduces an inline error message if the hint matches the password.
-   Adds new localization string for the error message.
-   Includes a minor fix in `Login/index.tsx` to correctly check for `hintText`.
