### PR TITLE
Fix: The Get started screen text is off to button

### DIFF
--- a/app/actions/multiSrp/index.ts
+++ b/app/actions/multiSrp/index.ts
@@ -3,17 +3,15 @@ import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import ExtendedKeyringTypes from '../../constants/keyringTypes';
 import Engine from '../../core/Engine';
 import { KeyringSelector } from '@metamask/keyring-controller';
-import { mnemonicToSeed } from '@metamask/key-tree';
+// import { mnemonicToSeed } from '@metamask/key-tree';
 ///: BEGIN:ONLY_INCLUDE_IF(seedless-onboarding)
 import ReduxService from '../../core/redux';
 import Logger from '../../util/Logger';
-import { uint8ArrayToMnemonic } from '../../util/mnemonic';
+// import { uint8ArrayToMnemonic } from '../../util/mnemonic';
 ///: END:ONLY_INCLUDE_IF(seedless-onboarding)
 
 export async function importNewSecretRecoveryPhrase(mnemonic: string) {
   const { KeyringController } = Engine.context;
-
-  const { SeedlessOnboardingController } = Engine.context;
 
   // Convert input mnemonic to codepoints
   const mnemonicWords = mnemonic.toLowerCase().split(' ');
@@ -69,6 +67,7 @@ export async function importNewSecretRecoveryPhrase(mnemonic: string) {
     // on Error, wallet should notify user that the newly added seed phrase is not synced properly
     // user can try manual sync again (phase 2)
     const seed = new Uint8Array(inputCodePoints.buffer);
+    const { SeedlessOnboardingController } = Engine.context;
     await SeedlessOnboardingController.addNewSeedPhraseBackup(
       seed,
       newKeyring.id,

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -9,6 +9,7 @@ import {
   InteractionManager,
   Animated,
   Easing,
+  Platform,
 } from 'react-native';
 import Text, {
   TextVariant,
@@ -75,18 +76,19 @@ const createStyles = (colors) =>
       paddingVertical: 30,
     },
     foxWrapper: {
-      width: 200,
-      height: 200,
+      width: Device.isLargeDevice() ? 200 : 175,
+      height: Device.isLargeDevice() ? 200 : 175,
       marginVertical: 20,
     },
     image: {
       alignSelf: 'center',
-      width: 200,
-      height: 200,
+      width: Device.isLargeDevice() ? 200 : 175,
+      height: Device.isLargeDevice() ? 200 : 175,
     },
     largeFoxWrapper: {
       alignItems: 'center',
-      marginVertical: 80,
+      paddingTop: Device.isLargeDevice() ? 60 : 40,
+      paddingBottom: Device.isLargeDevice() ? 100 : 40,
     },
     foxImage: {
       width: 145,
@@ -96,12 +98,10 @@ const createStyles = (colors) =>
     title: {
       fontSize: 40,
       lineHeight: 40,
-      marginBottom: 28,
       justifyContent: 'center',
       textAlign: 'center',
       paddingHorizontal: 60,
       fontFamily: 'MMSans-Regular',
-      marginTop: 80,
       color: brandColor,
     },
     ctas: {
@@ -622,12 +622,7 @@ class Onboarding extends PureComponent {
         >
           <View style={styles.wrapper}>
             {loading && (
-              <View style={styles.foxWrapper}>
-                {/* <Image
-                  source={require('../../../images/branding/fox.png')}
-                  style={styles.image}
-                  resizeMethod={'auto'}
-                /> */}
+              <View style={styles.largeFoxWrapper}>
                 <LottieView
                   style={styles.image}
                   autoPlay


### PR DESCRIPTION
Fix: The Get started screen text is off to button

- Handled large and small device heights for Padding and Margin 

ref: https://www.notion.so/metamask-consensys/1dcf86d67d68809f8d32e36fc7673584?v=1dcf86d67d6880f2b2bf000c62332ee0&p=1eef86d67d6880fab3fbe51025486f51&pm=s

PFA SS:
<img width="514" alt="Screenshot 2025-05-11 at 12 15 45 PM" src="https://github.com/user-attachments/assets/a087fa97-b5a7-45b3-98a3-be7c4a0a8664" />
