### PR TITLE
feat: add error tracing for onboarding flows

### DIFF
--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -482,6 +482,18 @@ const Login: React.FC = () => {
         setError(loginErrorMessage);
       }
       Logger.error(loginError, 'Failed to unlock');
+
+      // Check if we are in the onboarding flow
+      const onboardingTraceCtxFromRoute = route.params?.onboardingTraceCtx;
+      if (onboardingTraceCtxFromRoute) {
+        bufferedTrace({
+          name: TraceName.OnboardingPasswordLoginError,
+          op: TraceOperation.OnboardingError,
+          tags: { errorMessage: loginErrorMessage },
+          parentContext: onboardingTraceCtxFromRoute,
+        });
+        bufferedEndTrace({ name: TraceName.OnboardingPasswordLoginError });
+      }
     }
     endTrace({ name: TraceName.Login });
   };

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -484,7 +484,7 @@ class Onboarding extends PureComponent {
       const result = await OAuthLoginService.handleOAuthLogin(
         loginHandler,
       ).catch((e) => {
-        this.handleLoginError(e);
+        this.handleLoginError(e, 'apple');
         return { type: 'error', error: e, existingUser: false };
       });
       this.handlePostSocialLogin(result, createWallet);
@@ -505,7 +505,7 @@ class Onboarding extends PureComponent {
       const result = await OAuthLoginService.handleOAuthLogin(
         loginHandler,
       ).catch((error) => {
-        this.handleLoginError(error);
+        this.handleLoginError(error, 'google');
         return { type: 'error', error, existingUser: false };
       });
       this.handlePostSocialLogin(result, createWallet);
@@ -513,7 +513,7 @@ class Onboarding extends PureComponent {
     this.handleExistingUser(action);
   };
 
-  handleLoginError = (error) => {
+  handleLoginError = (error, socialConnectionType) => {
     let errorMessage;
     if (error instanceof OAuthError) {
       if (error.code === OAuthErrorType.UserCancelled) {
@@ -521,6 +521,22 @@ class Onboarding extends PureComponent {
       } else {
         errorMessage = 'oauth_error';
       }
+    }
+
+    bufferedTrace({
+      name: TraceName.OnboardingSocialLoginError,
+      op: TraceOperation.OnboardingError,
+      tags: { provider: socialConnectionType, errorMessage },
+      parentContext: this.onboardingTraceCtx,
+    });
+    bufferedEndTrace({ name: TraceName.OnboardingSocialLoginError });
+
+    if (this.socialLoginTraceCtx) {
+      bufferedEndTrace({
+        name: TraceName.OnboardingSocialLoginAttempt,
+        data: { success: false },
+      });
+      this.socialLoginTraceCtx = null;
     }
 
     this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -149,6 +149,18 @@ export class OAuthService {
         });
         result = await loginHandler.login();
         providerLoginSuccess = true;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+
+        bufferedTrace({
+          name: TraceName.OnboardingOAuthProviderLoginError,
+          op: TraceOperation.OnboardingError,
+          tags: { errorMessage },
+        });
+        bufferedEndTrace({ name: TraceName.OnboardingOAuthProviderLoginError });
+
+        throw error;
       } finally {
         bufferedEndTrace({
           name: TraceName.OnboardingOAuthProviderLogin,
@@ -171,6 +183,20 @@ export class OAuthService {
             this.config.authServerUrl,
           );
           getAuthTokensSuccess = true;
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : 'Unknown error';
+
+          bufferedTrace({
+            name: TraceName.OnboardingOAuthBYOAServerGetAuthTokensError,
+            op: TraceOperation.OnboardingError,
+            tags: { errorMessage },
+          });
+          bufferedEndTrace({
+            name: TraceName.OnboardingOAuthBYOAServerGetAuthTokensError,
+          });
+
+          throw error;
         } finally {
           bufferedEndTrace({
             name: TraceName.OnboardingOAuthBYOAServerGetAuthTokens,
@@ -206,6 +232,20 @@ export class OAuthService {
             authConnection,
           );
           seedlessAuthSuccess = true;
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : 'Unknown error';
+
+          bufferedTrace({
+            name: TraceName.OnboardingOAuthSeedlessAuthenticateError,
+            op: TraceOperation.OnboardingError,
+            tags: { errorMessage },
+          });
+          bufferedEndTrace({
+            name: TraceName.OnboardingOAuthSeedlessAuthenticateError,
+          });
+
+          throw error;
         } finally {
           bufferedEndTrace({
             name: TraceName.OnboardingOAuthSeedlessAuthenticate,

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -71,6 +71,11 @@ export enum TraceName {
   OnboardingOAuthProviderLogin = 'Onboarding - OAuth Provider Login',
   OnboardingOAuthBYOAServerGetAuthTokens = 'Onboarding - OAuth BYOA Server Get Auth Tokens',
   OnboardingOAuthSeedlessAuthenticate = 'Onboarding - OAuth Seedless Authenticate',
+  OnboardingSocialLoginError = 'Onboarding - Social Login Error',
+  OnboardingPasswordLoginError = 'Onboarding - Password Login Error',
+  OnboardingOAuthProviderLoginError = 'Onboarding - OAuth Provider Login Error',
+  OnboardingOAuthBYOAServerGetAuthTokensError = 'Onboarding - OAuth BYOA Server Get Auth Tokens Error',
+  OnboardingOAuthSeedlessAuthenticateError = 'Onboarding - OAuth Seedless Authenticate Error',
 }
 
 export enum TraceOperation {
@@ -92,6 +97,7 @@ export enum TraceOperation {
   AddSnapAccount = 'add.snap.account',
   OnboardingUserJourney = 'onboarding.user_journey',
   OnboardingSecurityOp = 'onboarding.security_operation',
+  OnboardingError = 'onboarding.error',
 }
 
 const ID_DEFAULT = 'default';


### PR DESCRIPTION
## **Description**
This PR enhances Sentry tracing for onboarding error states.

The key improvements include:
1.  **Error Traces**: New trace names (`OnboardingSocialLoginError`, `OnboardingPasswordLoginError`, `OnboardingOAuthProviderLoginError`, `OnboardingOAuthBYOAServerGetAuthTokensError`, `OnboardingOAuthSeedlessAuthenticateError`) and a new operation type (`OnboardingError`) have been introduced to specifically capture error details.